### PR TITLE
ci: twister: pytest: Enable pytest plugin in CI unit tests

### DIFF
--- a/.github/workflows/twister_tests.yml
+++ b/.github/workflows/twister_tests.yml
@@ -55,4 +55,6 @@ jobs:
         ZEPHYR_TOOLCHAIN_VARIANT: zephyr
       run: |
         echo "Run twister tests"
-        PYTHONPATH=./scripts/tests pytest ./scripts/tests/twister
+        PYTHONPATH=./scripts/tests \
+        export PYTHONPATH=./scripts/pylib/pytest-twister-harness/src:${PYTHONPATH} \
+        && pytest ./scripts/tests/twister


### PR DESCRIPTION
PYTHONPATH has to be expanded by the path to the pytest-twister-harness plugin to enable execution of corresponding unit tests.